### PR TITLE
Support websocket pings on an idle timeout

### DIFF
--- a/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocket.scala
+++ b/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocket.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.websocket
 
 import com.twitter.concurrent.Offer
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.{Duration, Future, Promise}
 import java.net.URI
 import org.jboss.netty.handler.codec.http.websocketx.WebSocketVersion
 import java.net.SocketAddress
@@ -14,4 +14,5 @@ case class WebSocket(
   remoteAddress: SocketAddress = new SocketAddress {},
   version: WebSocketVersion = WebSocketVersion.V13,
   onClose: Future[Unit] = new Promise[Unit],
-  close: () => Unit = { () => () })
+  close: () => Unit = { () => () },
+  var idlePingTimeout: Duration = Duration.Top)

--- a/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -2,7 +2,8 @@ package com.twitter.finagle.websocket
 
 import com.twitter.concurrent.{Offer, Broker}
 import com.twitter.finagle.netty3.Conversions._
-import com.twitter.util.{Promise, Return, Throw, Try}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util.{Duration, Promise, Return, Throw, Try}
 import java.net.URI
 import org.jboss.netty.buffer.ChannelBuffers
 import org.jboss.netty.channel._
@@ -49,6 +50,13 @@ class WebSocketHandler extends SimpleChannelHandler {
               val writeFuture = Channels.future(ctx.getChannel)
               Channels.write(ctx, writeFuture, frame)
               write(ctx, sock, Some(writeFuture.toTwitterFuture.toOffer))
+          },
+          timeout(sock.idlePingTimeout) map {
+            _ =>
+              val frame = new PingWebSocketFrame()
+              val writeFuture = Channels.future(ctx.getChannel)
+              Channels.write(ctx, writeFuture, frame)
+              write(ctx, sock, Some(writeFuture.toTwitterFuture.toOffer))
           }
         )
     }
@@ -57,6 +65,16 @@ class WebSocketHandler extends SimpleChannelHandler {
 
   override def channelClosed(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
     closer.setValue(())
+  }
+
+  // Offer.timeout(Duration.Top) fires immediately but it's logically what we
+  // want for an infinite timeout.
+  def timeout(d: Duration): Offer[Unit] = {
+    if (Duration.Top.compare(d) == 0) {
+      Offer.never
+    } else {
+      Offer.timeout(d)(DefaultTimer.twitter)
+    }
   }
 }
 

--- a/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/finagle-websocket/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -95,6 +95,8 @@ class WebSocketServerHandler extends WebSocketHandler {
       case frame: PingWebSocketFrame =>
         ctx.getChannel.write(new PongWebSocketFrame(frame.getBinaryData))
 
+      case frame: PongWebSocketFrame => { }
+
       case frame: TextWebSocketFrame =>
         val ch = ctx.getChannel
         ch.setReadable(false)
@@ -122,6 +124,12 @@ class WebSocketServerHandler extends WebSocketHandler {
       case _: CloseWebSocketFrame =>
         ctx.sendDownstream(e)
 
+      case _: PingWebSocketFrame =>
+        ctx.sendDownstream(e)
+
+      case _: PongWebSocketFrame =>
+        ctx.sendDownstream(e)
+
       case invalid =>
         Channels.fireExceptionCaught(ctx,
           new IllegalArgumentException("invalid message \"%s\"".format(invalid)))
@@ -144,6 +152,8 @@ class WebSocketClientHandler extends WebSocketHandler {
 
       case frame: PingWebSocketFrame =>
         ctx.getChannel.write(new PongWebSocketFrame(frame.getBinaryData))
+
+      case frame: PongWebSocketFrame => { }
 
       case frame: TextWebSocketFrame =>
         val ch = ctx.getChannel
@@ -186,6 +196,12 @@ class WebSocketClientHandler extends WebSocketHandler {
         ctx.sendDownstream(e)
 
       case _: CloseWebSocketFrame =>
+        ctx.sendDownstream(e)
+
+      case _: PingWebSocketFrame =>
+        ctx.sendDownstream(e)
+
+      case _: PongWebSocketFrame =>
         ctx.sendDownstream(e)
 
       case invalid =>


### PR DESCRIPTION
We're having issues with dropped websocket connections--easily reproduced by having a mobile client drop off the network (e.g. put it in a microwave for RF insulation and go into airplane mode). In this case, the onClose Future will never fire and cleanup can't occur.

There's some good background here: http://blog.stephencleary.com/2009/05/detection-of-half-open-dropped.html

We've decided to fix this by sending occasional websocket pings when the connection has been idle: they'll fail to send, the connection will be noticed as closed, and everything will shut down properly.

The first patch in this pull request is straightforward: it fills in support for PingWebSocketFrame and PongWebSocketFrame in the client and server handlers. These were caught as invalid messages before.

The second patch is more of a request for direction: it adds the idle timeout (good) with an awful configuration mechanism (`var WebSocket.idlePingTimeout`). This works for me, but it would be far better for this to go through the ServerBuilder or Codec instead of adding mutable state. I haven't figured out how Finagle would expect this to be done.
